### PR TITLE
[3.3.3] Saner blog post date format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/assets/post_manifest.json
+++ b/src/assets/post_manifest.json
@@ -8,27 +8,13 @@
             "id": "b5873d60-299f-4b24-a41c-b0b858a43f72",
             "title": "New blog - a new blog, a new static site generator ...ish",
             "path": "/posts/new-blog.md",
-            "date": {
-                "year": "2020",
-                "month": "10",
-                "day": "19",
-                "hr": "17",
-                "mins": "22",
-                "sec": "06"
-            }
+            "date": "2020-10-19T17:22:06"
         },
         {
             "id": "43445e7f-f18e-4715-8a1c-b7f9b31d3efc",
             "title": "Building a webdev automation tool",
             "path": "/posts/building-webdev-automation-tool.md",
-            "date": {
-                "year": "2021",
-                "month": "02",
-                "day": "05",
-                "hr": "14",
-                "mins": "58",
-                "sec": "08"
-            }
+            "date": "2021-02-05T14:58:08"
         }
     ]
 }

--- a/src/views/Blog.js
+++ b/src/views/Blog.js
@@ -31,7 +31,7 @@ function BlogPostPreview(props) {
       >
         <CardTitle className="grid grid-col-1 grid-gap-xs align-start justify-center">
           <h3 className="font-scale-xl">{props.post.title}</h3>
-          <sub>{new Date(props.post.date.year, props.post.date.month, props.post.date.day, props.post.date.hr, props.post.date.mins, props.post.date.sec).toLocaleString()}</sub>
+          <sub>{new Date(props.post.date).toLocaleString()}</sub>
         </CardTitle>
       </NavLink>
       <CardBody className="position-relative padding-none">

--- a/src/views/Post.js
+++ b/src/views/Post.js
@@ -34,7 +34,7 @@ function PostHeader(props) {
         </NavLink>
         <div className="vstack align-start justify-center">
           <h2 className="font-scale-xxl">{props.title}</h2>
-          <sub className="font-scale-s text-color-secondary">{new Date(props.date.year, props.date.month, props.date.day, props.date.hr, props.date.mins, props.date.sec).toLocaleString()}</sub>
+          <sub className="font-scale-s text-color-secondary">{new Date(props.date).toLocaleString()}</sub>
         </div>
       </div>
     </div>

--- a/statgen.py
+++ b/statgen.py
@@ -8,14 +8,7 @@ class Post:
     id = ""
     title = ""
     path = ""
-    date = {
-        'year': '',
-        'month': '',
-        'day': '',
-        'hr': '',
-        'mins': '',
-        'sec': ''
-    }
+    date = ""
 
     def __init__(self, post_id=None, title="", path="", date=None):
         if post_id is None:
@@ -25,17 +18,7 @@ class Post:
         self.title = title
         self.path = path
         if date is None:
-            timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
-            timestamp_date = timestamp.split(" ")[0].split("-")
-            timestamp_time = timestamp.split(" ")[1].split(":")
-            self.date = {
-                "year": timestamp_date[0],
-                "month": timestamp_date[1],
-                "day": timestamp_date[2],
-                "hr": timestamp_time[0],
-                "mins": timestamp_time[1],
-                "sec": timestamp_time[2]
-            }
+            self.date = datetime.today().strftime('%Y-%m-%dT%H:%M:%S')
         else:
             self.date = date
     


### PR DESCRIPTION
Changelog:
* Replace object-based date in `post_manifest.json` with standard timestamp string.
* Updated `stat_gen.py` to create new post entries using the new timestamp format.